### PR TITLE
Consider approved status as pending transaction

### DIFF
--- a/src/Messages/CompleteResponse.php
+++ b/src/Messages/CompleteResponse.php
@@ -64,7 +64,13 @@ class CompleteResponse extends Response
      */
     public function isPending(): bool
     {
-        return $this->extractRequestStatus() === self::STATUS_PENDING;
+        return in_array(
+            $this->extractRequestStatus(),
+            [
+                self::STATUS_PENDING,
+                self::STATUS_APPROVED
+            ]
+        , false);
     }
 
     /**


### PR DESCRIPTION
Some banlinks before completing transaction send response with status APPROVE. This PR should fix these cases.